### PR TITLE
Update for October spreadsheets

### DIFF
--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -19,8 +19,13 @@ if Pathname.new(filepath).extname != ".csv"
   exit 1
 end
 
+table_config = Osgeo::Termbase::Csv::Config.new(
+  header_row_index: 2, term_column: 0, type_column: 1, domain_column: 2,
+  comments_column: 3, definition_column: 4, authoritative_source_column: 5,
+  entry_status_column: 6,
+)
 
-table = Osgeo::Termbase::Csv.new(filepath)
+table = Osgeo::Termbase::Csv.new(filepath, table_config)
 
 # registries = {
 #   "eng" => {

--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -54,7 +54,8 @@ collection = Osgeo::Termbase::ConceptCollection.new
 
 concepts.each { |c| collection.add_term(c) }
 
-collection.to_file(File.join(output_dir, Pathname.new(filepath).basename.sub_ext(".yaml")))
+# Aggregated YAML
+# collection.to_file(File.join(output_dir, Pathname.new(filepath).basename.sub_ext(".yaml")))
 
 collection_output_dir = File.join(output_dir, "concepts")
 

--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -25,7 +25,7 @@ table = Osgeo::Termbase::Csv.new(filepath)
 # registries = {
 #   "eng" => {
 #     metadata: {},
-#     terms: table.concept_collection
+#     terms: table.to_concept_collection
 #   }
 # }
 
@@ -43,7 +43,7 @@ output_dir = Dir.pwd
 #   file.write(metadata.to_yaml)
 # end
 
-collection = table.concept_collection
+collection = table.to_concept_collection
 
 collection.to_file(File.join(output_dir, Pathname.new(filepath).basename.sub_ext(".yaml")))
 

--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -48,7 +48,11 @@ output_dir = Dir.pwd
 #   file.write(metadata.to_yaml)
 # end
 
-collection = table.to_concept_collection
+concepts = table.concepts
+
+collection = Osgeo::Termbase::ConceptCollection.new
+
+concepts.each { |c| collection.add_term(c) }
 
 collection.to_file(File.join(output_dir, Pathname.new(filepath).basename.sub_ext(".yaml")))
 

--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -6,26 +6,43 @@ require 'fileutils'
 require_relative '../lib/osgeo/termbase.rb'
 # require 'pry'
 
-filepath = ARGV[0]
-#'./osgeo-termbase.xlsx'
+abbrev_filepath = ARGV[0]
+proposed_filepath = ARGV[1]
 
-if filepath.nil?
-  puts 'Error: no filepath given as first argument.'
+if abbrev_filepath.nil?
+  puts 'Error: no abbrev_filepath given as first argument.'
   exit 1
 end
 
-if Pathname.new(filepath).extname != ".csv"
-  puts 'Error: filepath given must have extension .csv.'
+if Pathname.new(abbrev_filepath).extname != ".csv"
+  puts 'Error: abbrev_filepath given must have extension .csv.'
   exit 1
 end
 
-table_config = Osgeo::Termbase::Csv::Config.new(
-  header_row_index: 2, term_column: 0, type_column: 1, domain_column: 2,
-  comments_column: 3, definition_column: 4, authoritative_source_column: 5,
-  entry_status_column: 6,
+if proposed_filepath.nil?
+  puts 'Error: no proposed_filepath given as second argument.'
+  exit 1
+end
+
+if Pathname.new(proposed_filepath).extname != ".csv"
+  puts 'Error: proposed_filepath given must have extension .csv.'
+  exit 1
+end
+
+abbreviations_table_config = Osgeo::Termbase::Csv::Config.new(
+  header_row_index: 2, term_abbrev_column: 0, comments_column: 5,
+  definition_column: 6, source_link_column: 7,
 )
 
-table = Osgeo::Termbase::Csv.new(filepath, table_config)
+# TODO Authoritative source is not a link
+proposed_table_config = Osgeo::Termbase::Csv::Config.new(
+  header_row_index: 5, term_preferred_column: 0, term_admitted_column: 1,
+  term_abbrev_column: 2, definition_column: 5, comments_column: 6,
+  source_comment_column: 7,
+)
+
+abbreviations = Osgeo::Termbase::Csv.new(abbrev_filepath, abbreviations_table_config).concepts
+proposed = Osgeo::Termbase::Csv.new(proposed_filepath, proposed_table_config).concepts
 
 # registries = {
 #   "eng" => {
@@ -48,11 +65,14 @@ output_dir = Dir.pwd
 #   file.write(metadata.to_yaml)
 # end
 
-concepts = table.concepts
+
+# Merge concept arrays
+merged_terms = abbreviations + proposed
+merged_terms.sort_by! { |t| t.default_designation.downcase }
+merged_terms.each.with_index { |t, i| t.id = i + 1 } # Re-calculate ids
 
 collection = Osgeo::Termbase::ConceptCollection.new
-
-concepts.each { |c| collection.add_term(c) }
+merged_terms.each { |t| collection.add_term(t) }
 
 # Aggregated YAML
 # collection.to_file(File.join(output_dir, Pathname.new(filepath).basename.sub_ext(".yaml")))

--- a/lib/osgeo/termbase/concept.rb
+++ b/lib/osgeo/termbase/concept.rb
@@ -39,7 +39,7 @@ class Concept < Hash
 
   def to_hash
     default_hash = {
-      "term" => default_term.term,
+      "term" => (default_term.default_designation),
       "termid" => id
     }
 

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -44,27 +44,31 @@ class Csv
     csv.each_with_index do |row, i|
       next if i < 3
 
-      term = Term.new(
-        id: i - 2,
-        term: row[0],
-        type: row[1],
-        domain: row[2],
-        comments: row[3] && [row[3]],
-        definition: row[4],
-        authoritative_source: {
-          "link" => row[5],
-          # ref: '',
-          # clause: ''
-        },
-        entry_status: row[6],
-        language_code: "eng"
-      )
+      term = parse_csv_row(row, i)
 
       # puts term.to_hash
       collection.add_term(term)
     end
 
     collection
+  end
+
+  def parse_csv_row(row, i)
+    Term.new(
+      id: i - 2,
+      term: row[0],
+      type: row[1],
+      domain: row[2],
+      comments: row[3] && [row[3]],
+      definition: row[4],
+      authoritative_source: {
+        "link" => row[5],
+        # ref: '',
+        # clause: ''
+      },
+      entry_status: row[6],
+      language_code: "eng"
+    )
   end
 
 end

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -65,12 +65,6 @@ class Csv
     concepts
   end
 
-  def to_concept_collection
-    collection = ConceptCollection.new
-    concepts.each { |c| collection.add_term(c) }
-    collection
-  end
-
   def parse_csv_row(row, i)
     get_column = ->(name, wrap_in_array: false) do
       column_idx = config.send(:"#{name}_column")

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -3,16 +3,14 @@ require "csv"
 require "yaml"
 require "pathname"
 
+require_relative "term"
+
 module Osgeo::Termbase
 
 class Csv
   attr_accessor :filename, :config
 
-  COLUMN_MEANINGS = %w[
-    term type domain comments definition authoritative_source entry_status
-  ]
-
-  COLUMN_ATTR_NAMES = COLUMN_MEANINGS.map { |str| :"#{str}_column" }
+  COLUMN_ATTR_NAMES = Osgeo::Termbase::Term::INPUT_ATTRIBS.map { |str| :"#{str}_column" }
 
   # Spreadsheet config
   Config = Struct.new(:header_row_index, *COLUMN_ATTR_NAMES, keyword_init: true)
@@ -74,18 +72,13 @@ class Csv
 
     Term.new(
       id: i - config.header_row_index,
-      term: get_column.(:term),
-      type: get_column.(:type),
-      domain: get_column.(:domain),
+      term_preferred: get_column.(:term_preferred),
+      term_admitted: get_column.(:term_admitted),
+      term_abbrev: get_column.(:term_abbrev),
       comments: get_column.(:comments, wrap_in_array: true),
       definition: get_column.(:definition),
-      authoritative_source: {
-        "link" => get_column.(:authoritative_source),
-        # ref: '',
-        # clause: ''
-      },
-      entry_status: get_column.(:entry_status),
-      language_code: "eng"
+      source_comment: get_column.(:source_comment),
+      source_link: get_column.(:source_link),
     )
   end
 

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -22,6 +22,10 @@ class Csv
     @csv ||= load_csv
   end
 
+  def concepts
+    @concepts ||= load_concepts
+  end
+
   def load_csv
     raw = File.read(@filename)
 
@@ -38,18 +42,22 @@ class Csv
     )
   end
 
-  def concept_collection
-    collection = ConceptCollection.new
+  def load_concepts
+    # Was easier to change than #inject
+    concepts = []
 
     csv.each_with_index do |row, i|
       next if i < 3
-
       term = parse_csv_row(row, i)
-
-      # puts term.to_hash
-      collection.add_term(term)
+      concepts.push(term)
     end
 
+    concepts
+  end
+
+  def to_concept_collection
+    collection = ConceptCollection.new
+    concepts.each { |c| collection.add_term(c) }
     collection
   end
 

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -18,25 +18,32 @@ class Csv
     "eng"
   end
 
-  def concept_collection
-    collection = ConceptCollection.new
+  def csv
+    @csv ||= load_csv
+  end
 
-    csv_content = File.read(@filename)
+  def load_csv
+    raw = File.read(@filename)
 
     # Google Sheets always uses \n at the last line end, but \r\n for all other line breaks
     # which causes Ruby's CSV to show this error:
     # CSV::MalformedCSVError: Unquoted fields do not allow \r or \n
     # Here we replace the DOS \r\n with Unix \n
-    csv_content = csv_content.gsub(/\r\n/, "\n")
-
-    # puts csv_content
+    csv_content = raw.gsub(/\r\n/, "\n")
 
     CSV.new(
       csv_content,
       liberal_parsing: true,
       skip_blanks: true
-    ).each_with_index do |row, i|
+    )
+  end
+
+  def concept_collection
+    collection = ConceptCollection.new
+
+    csv.each_with_index do |row, i|
       next if i < 3
+
       term = Term.new(
         id: i - 2,
         term: row[0],


### PR DESCRIPTION
Spreadsheets from October 2020 required some enhancements to this very project. This pull request contains a forgotten set of commits, which helped to import data back then (https://github.com/geolexica/osgeo-glossary/pull/10). Most importantly, it adds support for two-sheet exports (separate sheets for proposed terms and abbreviations).

Note that produced YAMLs require a little post-processing, that is some authoritative sources need to be split into `ref` and `clause`. This is because it was easier to do this manually, especially that no future imports were expected.