### PR TITLE
Update for December 2020 spreadsheets

### DIFF
--- a/exe/osgeo-termbase-csv2yaml
+++ b/exe/osgeo-termbase-csv2yaml
@@ -6,43 +6,26 @@ require 'fileutils'
 require_relative '../lib/osgeo/termbase.rb'
 # require 'pry'
 
-abbrev_filepath = ARGV[0]
-proposed_filepath = ARGV[1]
+filepath = ARGV[0]
 
-if abbrev_filepath.nil?
-  puts 'Error: no abbrev_filepath given as first argument.'
+if filepath.nil?
+  puts 'Error: no filepath given as first argument.'
   exit 1
 end
 
-if Pathname.new(abbrev_filepath).extname != ".csv"
-  puts 'Error: abbrev_filepath given must have extension .csv.'
+if Pathname.new(filepath).extname != ".csv"
+  puts 'Error: filepath given must have extension .csv.'
   exit 1
 end
 
-if proposed_filepath.nil?
-  puts 'Error: no proposed_filepath given as second argument.'
-  exit 1
-end
-
-if Pathname.new(proposed_filepath).extname != ".csv"
-  puts 'Error: proposed_filepath given must have extension .csv.'
-  exit 1
-end
-
-abbreviations_table_config = Osgeo::Termbase::Csv::Config.new(
-  header_row_index: 2, term_abbrev_column: 0, comments_column: 5,
-  definition_column: 6, source_link_column: 7,
+table_config = Osgeo::Termbase::Csv::Config.new(
+  header_row_index: 2, term_preferred_column: 1, term_admitted_column: 2,
+  term_abbrev_column: 3, definition_column: 4, source_link_column: 11,
+  example1_column: 5, example2_column: 7, example3_column: 9,
+  note1_column: 6, note2_column: 8, note3_column: 10,
 )
 
-# TODO Authoritative source is not a link
-proposed_table_config = Osgeo::Termbase::Csv::Config.new(
-  header_row_index: 5, term_preferred_column: 0, term_admitted_column: 1,
-  term_abbrev_column: 2, definition_column: 5, comments_column: 6,
-  source_comment_column: 7,
-)
-
-abbreviations = Osgeo::Termbase::Csv.new(abbrev_filepath, abbreviations_table_config).concepts
-proposed = Osgeo::Termbase::Csv.new(proposed_filepath, proposed_table_config).concepts
+concepts = Osgeo::Termbase::Csv.new(filepath, table_config).concepts
 
 # registries = {
 #   "eng" => {
@@ -67,7 +50,7 @@ output_dir = Dir.pwd
 
 
 # Merge concept arrays
-merged_terms = abbreviations + proposed
+merged_terms = concepts
 merged_terms.sort_by! { |t| t.default_designation.downcase }
 merged_terms.each.with_index { |t, i| t.id = i + 1 } # Re-calculate ids
 

--- a/lib/osgeo/termbase/csv.rb
+++ b/lib/osgeo/termbase/csv.rb
@@ -79,6 +79,12 @@ class Csv
       definition: get_column.(:definition),
       source_comment: get_column.(:source_comment),
       source_link: get_column.(:source_link),
+      note1: get_column.(:note1),
+      note2: get_column.(:note2),
+      note3: get_column.(:note3),
+      example1: get_column.(:example1),
+      example2: get_column.(:example2),
+      example3: get_column.(:example3),
     )
   end
 

--- a/lib/osgeo/termbase/term.rb
+++ b/lib/osgeo/termbase/term.rb
@@ -22,6 +22,12 @@ class Term
     definition
     source_link
     source_comment
+    note1
+    note2
+    note3
+    example1
+    example2
+    example3
   )
 
   attr_accessor *INPUT_ATTRIBS
@@ -29,8 +35,6 @@ class Term
 
   def initialize(**attrs)
     @language_code = "eng"
-    @notes = []
-    @examples = []
 
     assing_attributes(**attrs)
   end
@@ -39,6 +43,14 @@ class Term
     attrs.each_pair do |name, value|
       public_send(:"#{name}=", value)
     end
+  end
+
+  def notes
+    [note1, note2, note3].compact
+  end
+
+  def examples
+    [example1, example2, example3].compact
   end
 
   # The termid should ALWAYS be an integer.


### PR DESCRIPTION
Program updates related to https://github.com/geolexica/osgeo-glossary/issues/7.

@ronaldtse a few things to note:

- Some concepts may need sanitizing, I'm not sure. For instance, concept 215 (Keyhole Markup Language) contains note with irregular quotes which says: `The name originates from the company which developed the technology, originally named “Keyhole”.` These quotes don't look buggy nor they affect parsing.
- Instead of parsing ID column, I sort concepts by primary designation and assign the ordinal number. This is what we did before for OSGeo spreadsheets and I guess this is what is desired. Anyway, I haven't found any discrepancies.
- There used to be maintainer comments in the previous spreadsheets, but they are missing in the latest one. I presume this is correct.
- Term "raster" is defined twice with different descriptions (Term ID 337 and 338).
- I will be AFK for the weekend. If there are any comments, I will handle them on Monday.